### PR TITLE
Pin the dependences' versions

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -36,7 +36,7 @@
 			<arg value="--conda_prefix"/>
 			<arg value="${conda.dir}"/>
 			<arg value="--galaxy_branch"/>
-			<arg value="release_16.01"/>
+			<arg value="release_17.05"/>
 			<arg value="--conda_dependency_resolution"/>
 			<arg value="${tool.xml}"/>
 		</exec>

--- a/transformation_config.xml
+++ b/transformation_config.xml
@@ -2,7 +2,7 @@
   <description>Transforms the dataMatrix intensity values</description>
   
   <requirements>
-    <requirement type="package">r-batch</requirement>
+    <requirement type="package" version="1.1_4">r-batch</requirement>
   </requirements>
 
   <stdio>

--- a/transformation_config.xml
+++ b/transformation_config.xml
@@ -78,7 +78,6 @@ Workflow position
 |
     
 .. image:: transformation_workflowPositionImage.png
-:width: 600
     
     
     


### PR DESCRIPTION
Otherwise, Conda will always take the laster one.